### PR TITLE
Webapp: Fix the new `WebCall` mechanism.

### DIFF
--- a/webapp/turntable/models.py
+++ b/webapp/turntable/models.py
@@ -220,11 +220,11 @@ class WebCallRequestHttp11(WebCallRequest):
         }
 
     @staticmethod
-    def from_request(self, request):
+    def from_request(request):
         return WebCallRequestHttp11(
             method=request.method,
             headers={k: v for k, v in request.headers.items()},
-            bookies=request.cookies,
+            cookies=request.cookies,
             body=request.get_data(as_text=True),
             source_ip=request.remote_addr,
             source_url=request.url)

--- a/webapp/turntable/pivot/resources.py
+++ b/webapp/turntable/pivot/resources.py
@@ -2,7 +2,7 @@ from . import blueprint
 
 from turntable.visitor_business import VisitorBusiness
 from turntable.exceptions import BusinessException
-from turntable.models import WebCall
+from turntable.models import WebCall, WebCallRequestHttp11
 from flask import request, g, session, redirect, url_for, current_app
 import json
 
@@ -15,7 +15,8 @@ def push(pid, uri_append=None):
     app.logger.info("Handling new request for pivot=<{}>".format(pid))
 
     try:
-        VisitorBusiness().publish(pid, WebCall.from_request(request))
+        httpreq = WebCallRequestHttp11.from_request(request)
+        VisitorBusiness().publish(pid, WebCall(httpreq))
         return json.dumps({'success':True}), 200, {'ContentType':'application/json'}
 
     except BusinessException as e:


### PR DESCRIPTION
Changes:
  - `WebCallRequestHttp11.from_request()`: method is static, hence, no
    need to add `self` in the function signature.
  - `WebCallRequestHttp11.from_request()`: fix typo in parameter name.
  - Update the Flask handler for `/pivot` to work (I might have missed
    something here…).