### PR TITLE
fix(client) fix state saving in files if directory already exist

### DIFF
--- a/client/turnt/state.go
+++ b/client/turnt/state.go
@@ -42,7 +42,7 @@ func LoadRequestID() (string, error) {
 func save(request Job, serviceName, cuuid string) error {
 	spath := path.Join(storePath, serviceName, cuuid)
 
-	if _, err := os.Stat(spath); os.IsNotExist(err) {
+	if _, err := os.Stat(path.Dir(spath)); os.IsNotExist(err) {
 		err = os.Mkdir(path.Dir(spath), 0755)
 		if err != nil {
 			return err


### PR DESCRIPTION
This fixes the case where the client UUID is another one than an
already created uuid.

example:

`/var/tmp/turnt/1234` exist and you try to run another client with uuid
`4567`, it wont work because the test was wrong.